### PR TITLE
Add docs sitemap to robots.txt

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source "https://rubygems.org"
 
 gem "github-pages", group: :jekyll_plugins
 gem 'faraday', '0.17.3'
+gem "webrick", "~> 1.8"
 
 group :jekyll_plugins do
   gem "jekyll-include-cache"

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,5 @@
+---
+layout: none
+---
+Sitemap: {{ "sitemap.xml" | absolute_url }}
+Sitemap: {{ "docs/sitemap.xml" | absolute_url }}


### PR DESCRIPTION
Related to https://github.com/bonsai-rx/docs/pull/91 (Merge before this one)

Before this change, robots.txt was getting automatically generated by `jekyll-sitemap` for the main sitemap, so the main entry isn't actually new.

Also adds `webrick` to Gemfile, which is required to use `jekyll serve` with recent versions of Ruby as noted here: https://jekyllrb.com/docs/