### PR TITLE
Fix Discord invite link

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -113,7 +113,7 @@ footer:
       url: https://neuromatch.social/@bonsai
     - label: "Discord"
       icon: "fab fa-brands fa-discord"
-      url: https://discord.gg/zUhuDcYuJH
+      url: https://discord.gg/QcthRPuZnr
     - label: "GitHub"
       icon: "fab fa-fw fa-github"
       url: https://github.com/bonsai-rx/bonsai

--- a/_pages/community.md
+++ b/_pages/community.md
@@ -5,7 +5,7 @@ permalink: /community/
 author_profile: false
 ---
 
- * [Public Discord server](https://discord.gg/zUhuDcYuJH){:target="_blank"}
+ * [Public Discord server](https://discord.gg/QcthRPuZnr){:target="_blank"}
 
  * [GitHub Discussions forum](https://github.com/bonsai-rx/bonsai/discussions){:target="_blank"}
 


### PR DESCRIPTION
The Discord invite link is broken again, and since it seems anyone in the server can generate an invite link, I generated one that is set to never expire and with an unlimited number of users and replaced the current Discord link there. I am worried about losing users that might have wanted to join but got turned away because of a broken link if it keeps happening. I don't remember, but was the previous invite link user-limited so that we could refresh the link to avoid spam or bots? There is an option in Discord for administrators to revoke the permanent invite link if spam/bots are detected. I also tried to see if there was an "expired link checker bot" if we wanted to keep the link sort of temporary, but a cursory search didn't yield anything.